### PR TITLE
Fixed issue with StructureMapDependencyResolver to allow it to work out with ASP.NET.

### DIFF
--- a/src/structuremap/OpenRasta.DI.StructureMap/StructureMapDependencyResolver.cs
+++ b/src/structuremap/OpenRasta.DI.StructureMap/StructureMapDependencyResolver.cs
@@ -29,13 +29,13 @@ namespace OpenRasta.DI.StructureMap
 			switch (lifetime)
 			{
 				case DependencyLifetime.PerRequest:
-					return InstanceScope.HttpContext;
+					return InstanceScope.Hybrid;
 				case DependencyLifetime.Singleton:
 					return InstanceScope.Singleton;
 				case DependencyLifetime.Transient:
 					return InstanceScope.Transient;
 				default:
-					return InstanceScope.HttpContext;
+                    return InstanceScope.Hybrid;
 			}
 		}
 


### PR DESCRIPTION
Replaced instances of InstanceScope.HttpContext with InstanceScope.Hybrid to allow StructureMapDependencyResolver to be used out with ASP.NET.

Previously, StructureMapDependencyResolver would internally translate DependencyLifetime.PerRequest to InstanceScope.HttpContext. This is fine within an ASP.NET host, but causes an issue when using a host which does not have access to HttpContext.

To solve this, I modified StructureMapDependencyResolver, replacing instances of InstanceScope.HttpContext  with InstanceScope.Hybrid, which from the StructureMap documentation:
  "Uses HttpContext storage if it exists, otherwise uses ThreadLocal storage"
- http://structuremap.net/structuremap/Scoping.htm
