### PR TITLE
Use UTF-8 without BOM in XmlCodec

### DIFF
--- a/src/openrasta-core/src/OpenRasta/Codecs/application/xml/XmlCodec.cs
+++ b/src/openrasta-core/src/OpenRasta/Codecs/application/xml/XmlCodec.cs
@@ -29,6 +29,7 @@ namespace OpenRasta.Codecs
             using (Writer = XmlWriter.Create(responseStream, 
                                              new XmlWriterSettings
                                              {
+                                                 Encoding = new UTF8Encoding(false),
                                                  ConformanceLevel =
                                                      ConformanceLevel.Document, 
                                                  Indent = true, 


### PR DESCRIPTION
When initializing XmlWriter in XmlCodec, specify encoding explicitly to be UTF-8 without BOM as it's not needed for UTF-8.

ref: http://groups.google.com/group/openrasta/browse_thread/thread/6555c471e6563063?pli=1
